### PR TITLE
chore: buildFile 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,3 +29,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
Springboot 2.5 이후, jar명령을 수행 시, Plain.jar 파일이 생성되는 이슈가 있어 jar 명령은 제외시킴. bootJar 명령을 통해 배포에 사용할 jar 생성