### PR TITLE
feat: 공통 예외 handler 구현

### DIFF
--- a/src/main/java/org/colcum/admin/global/Error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/colcum/admin/global/Error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package org.colcum.admin.global.Error.handler;
+
+import org.colcum.admin.global.Error.EmailValidationException;
+import org.colcum.admin.global.Error.InvalidAuthenticationException;
+import org.colcum.admin.global.Error.PostNotFoundException;
+import org.colcum.admin.global.common.api.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ExceptionHandler(value = {PostNotFoundException.class, UsernameNotFoundException.class})
+    public ApiResponse<Void> handleNotFoundException(Exception ex) {
+        return new ApiResponse<>(HttpStatus.NOT_FOUND.value(), ex.getMessage(), null);
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(value = EmailValidationException.class)
+    public ApiResponse<Void> handleEmailValidationException(EmailValidationException ex) {
+        return new ApiResponse<>(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), null);
+    }
+
+    @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(value = InvalidAuthenticationException.class)
+    public ApiResponse<Void> handleInvalidAuthenticationException(InvalidAuthenticationException ex) {
+        return new ApiResponse<>(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), null);
+    }
+
+}

--- a/src/main/java/org/colcum/admin/global/auth/api/AuthenticationFailureHandler.java
+++ b/src/main/java/org/colcum/admin/global/auth/api/AuthenticationFailureHandler.java
@@ -1,0 +1,30 @@
+package org.colcum.admin.global.auth.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.units.qual.A;
+import org.colcum.admin.global.Error.InvalidAuthenticationException;
+import org.colcum.admin.global.common.api.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(new ApiResponse<Void>(HttpStatus.UNAUTHORIZED.value(), exception.getMessage(), null)));;
+    }
+
+}

--- a/src/main/java/org/colcum/admin/global/auth/application/UserAuthenticationService.java
+++ b/src/main/java/org/colcum/admin/global/auth/application/UserAuthenticationService.java
@@ -24,7 +24,7 @@ public class UserAuthenticationService implements UserDetailsService {
     @Transactional
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         UserEntity user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new UsernameNotFoundException(MessageFormat.format("대상 이메일 : %s가 존재하지 않습니다", email)));
+            .orElseThrow(() -> new UsernameNotFoundException(MessageFormat.format("대상 이메일 : {0}이 존재하지 않습니다", email)));
 
         List<SimpleGrantedAuthority> roles = List.of(new SimpleGrantedAuthority(user.getUserType().name()));
 

--- a/src/main/java/org/colcum/admin/global/auth/config/SecurityConfiguration.java
+++ b/src/main/java/org/colcum/admin/global/auth/config/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package org.colcum.admin.global.auth.config;
 
 import lombok.RequiredArgsConstructor;
 import org.colcum.admin.domain.user.domain.UserType;
+import org.colcum.admin.global.auth.api.AuthenticationFailureHandler;
 import org.colcum.admin.global.auth.api.AuthenticationSuccessHandler;
 import org.colcum.admin.global.auth.api.LoggingFilter;
 import org.colcum.admin.global.auth.application.UserAuthenticationProvider;
@@ -51,6 +52,7 @@ public class SecurityConfiguration {
                 form -> form
                     .permitAll()
                     .successHandler(new AuthenticationSuccessHandler(jwt()))
+                    .failureHandler(new AuthenticationFailureHandler())
             );
         return http.build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈번호
This close #16 


## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

예외 발생 시, 처리하기 위한 공통 예외 처리 Handler 를 구현하였습니다. 현재까지는 3개의 예외에 대해서만 처리 됩니다.
- InvaildationAuthentcationException
- PostNotFoundException
- EmailVaildationException