### PR TITLE
Feature/#18 implement bookmark api

### DIFF
--- a/src/main/java/org/colcum/admin/domain/post/api/PostController.java
+++ b/src/main/java/org/colcum/admin/domain/post/api/PostController.java
@@ -123,4 +123,30 @@ public class PostController {
         return new ApiResponse<>(HttpStatus.OK.value(), "success", responses);
     }
 
+    @PostMapping("/{postId}/bookmarks")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<Void> addBookmark(
+        @PathVariable(value = "postId") Long postId,
+        @AuthenticationPrincipal JwtAuthentication authentication
+    ) {
+        if (Objects.isNull(authentication)) {
+            throw new InvalidAuthenticationException("해당 서비스는 로그인 후 사용하실 수 있습니다.");
+        }
+        postService.addBookmark(postId, authentication.userEntity);
+        return new ApiResponse<>(HttpStatus.OK.value(), "success", null);
+    }
+
+    @DeleteMapping("/{postId}/bookmarks")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<Void> removeBookmark(
+        @PathVariable(value = "postId") Long postId,
+        @AuthenticationPrincipal JwtAuthentication authentication
+    ) {
+        if (Objects.isNull(authentication)) {
+            throw new InvalidAuthenticationException("해당 서비스는 로그인 후 사용하실 수 있습니다.");
+        }
+        postService.removeBookmark(postId, authentication.userEntity);
+        return new ApiResponse<>(HttpStatus.OK.value(), "success", null);
+    }
+
 }

--- a/src/main/java/org/colcum/admin/domain/post/api/PostController.java
+++ b/src/main/java/org/colcum/admin/domain/post/api/PostController.java
@@ -1,6 +1,7 @@
 package org.colcum.admin.domain.post.api;
 
 import lombok.RequiredArgsConstructor;
+import org.colcum.admin.domain.post.api.dto.PostBookmarkedResponse;
 import org.colcum.admin.domain.post.api.dto.PostCreateDto;
 import org.colcum.admin.domain.post.api.dto.PostDetailResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
@@ -108,6 +109,18 @@ public class PostController {
         }
         postService.deletePost(postId, authentication.userEntity);
         return new ApiResponse<>(HttpStatus.OK.value(), "success", null);
+    }
+
+    @GetMapping("/bookmarks")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<List<PostBookmarkedResponse>> inquirePostsWithBookmarked(
+        @AuthenticationPrincipal JwtAuthentication authentication
+    ) {
+        if (Objects.isNull(authentication)) {
+            throw new InvalidAuthenticationException("해당 서비스는 로그인 후 사용하실 수 있습니다.");
+        }
+        List<PostBookmarkedResponse> responses = postService.findBookmarkedPosts(authentication.userEntity);
+        return new ApiResponse<>(HttpStatus.OK.value(), "success", responses);
     }
 
 }

--- a/src/main/java/org/colcum/admin/domain/post/api/dto/PostBookmarkedResponse.java
+++ b/src/main/java/org/colcum/admin/domain/post/api/dto/PostBookmarkedResponse.java
@@ -1,0 +1,20 @@
+package org.colcum.admin.domain.post.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.colcum.admin.domain.post.domain.PostEntity;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostBookmarkedResponse {
+
+    private Long postId;
+    private String title;
+
+    public static PostBookmarkedResponse from(PostEntity post) {
+        return new PostBookmarkedResponse(post.getId(), post.getTitle());
+    }
+
+}

--- a/src/main/java/org/colcum/admin/domain/post/api/dto/PostCreateDto.java
+++ b/src/main/java/org/colcum/admin/domain/post/api/dto/PostCreateDto.java
@@ -30,7 +30,6 @@ public class PostCreateDto {
             content,
             category,
             status,
-            false,
             expiredDate,
             user
         );

--- a/src/main/java/org/colcum/admin/domain/post/api/dto/PostDetailResponseDto.java
+++ b/src/main/java/org/colcum/admin/domain/post/api/dto/PostDetailResponseDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.colcum.admin.domain.post.domain.PostEntity;
 import org.colcum.admin.domain.post.domain.type.PostCategory;
 import org.colcum.admin.domain.post.domain.type.PostStatus;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -68,7 +69,7 @@ public class PostDetailResponseDto {
             post.getContent(),
             post.getCategory(),
             post.getStatus(),
-            post.isBookmarked(),
+            post.getUser().getBookmarks().contains(new Bookmark(post.getId())),
             post.getExpiredDate(),
             post.getUser().getName(),
             post.getCreatedAt(),

--- a/src/main/java/org/colcum/admin/domain/post/api/dto/PostResponseDto.java
+++ b/src/main/java/org/colcum/admin/domain/post/api/dto/PostResponseDto.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.colcum.admin.domain.post.domain.PostEntity;
 import org.colcum.admin.domain.post.domain.type.PostStatus;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
 
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class PostResponseDto {
             entity.getContent(),
             entity.getStatus(),
             entity.getUser().getName(),
-            entity.isBookmarked(),
+            entity.getUser().getBookmarks().contains(new Bookmark(entity.getId())),
             entity.getCommentEntities().size(),
             EmojiResponseDto.from(entity.getEmojiReactionEntities())
         );

--- a/src/main/java/org/colcum/admin/domain/post/application/PostService.java
+++ b/src/main/java/org/colcum/admin/domain/post/application/PostService.java
@@ -12,7 +12,9 @@ import org.colcum.admin.domain.post.domain.PostEntity;
 import org.colcum.admin.domain.post.domain.type.PostCategory;
 import org.colcum.admin.domain.post.domain.type.PostStatus;
 import org.colcum.admin.domain.post.domain.type.SearchType;
+import org.colcum.admin.domain.user.dao.UserRepository;
 import org.colcum.admin.domain.user.domain.UserEntity;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
 import org.colcum.admin.global.Error.InvalidAuthenticationException;
 import org.colcum.admin.global.Error.PostNotFoundException;
 import org.springframework.data.domain.Page;
@@ -27,6 +29,8 @@ import java.util.List;
 public class PostService {
 
     private final PostRepository postRepository;
+
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public Page<PostResponseDto> findByCriteria(SearchType searchType, String searchValue, List<PostCategory> categories, List<PostStatus> statuses, Pageable pageable) {
@@ -82,6 +86,18 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<PostBookmarkedResponse> findBookmarkedPosts(UserEntity user) {
         return postRepository.findWithBookmarked(user.getId());
+    }
+
+    @Transactional
+    public void addBookmark(Long postId, UserEntity user) {
+        user.addBookmark(new Bookmark(postId));
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void removeBookmark(Long postId, UserEntity user) {
+        user.removeBookmark(new Bookmark(postId));
+        userRepository.save(user);
     }
 
 }

--- a/src/main/java/org/colcum/admin/domain/post/application/PostService.java
+++ b/src/main/java/org/colcum/admin/domain/post/application/PostService.java
@@ -1,6 +1,7 @@
 package org.colcum.admin.domain.post.application;
 
 import lombok.RequiredArgsConstructor;
+import org.colcum.admin.domain.post.api.dto.PostBookmarkedResponse;
 import org.colcum.admin.domain.post.api.dto.PostCreateDto;
 import org.colcum.admin.domain.post.api.dto.PostDetailResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
@@ -76,6 +77,11 @@ public class PostService {
         }
         post.delete();
         postRepository.save(post);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostBookmarkedResponse> findBookmarkedPosts(UserEntity user) {
+        return postRepository.findWithBookmarked(user.getId());
     }
 
 }

--- a/src/main/java/org/colcum/admin/domain/post/dao/CustomPostRepository.java
+++ b/src/main/java/org/colcum/admin/domain/post/dao/CustomPostRepository.java
@@ -1,19 +1,24 @@
 package org.colcum.admin.domain.post.dao;
 
+import org.colcum.admin.domain.post.api.dto.PostBookmarkedResponse;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostSearchCondition;
 import org.colcum.admin.domain.post.domain.PostEntity;
+import org.colcum.admin.domain.user.domain.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CustomPostRepository {
 
     Page<PostResponseDto> search(PostSearchCondition condition, Pageable pageable);
 
-    Optional<PostEntity> findByIdWithUser(Long id);
+    Optional<PostEntity> findByIdWithUser(Long userId);
 
     Optional<PostEntity> findByIdAndDeletedIsFalse(Long id);
+
+    List<PostBookmarkedResponse> findWithBookmarked(Long userId);
 
 }

--- a/src/main/java/org/colcum/admin/domain/post/dao/CustomPostRepositoryImpl.java
+++ b/src/main/java/org/colcum/admin/domain/post/dao/CustomPostRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.colcum.admin.domain.post.dao;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -9,11 +10,14 @@ import org.colcum.admin.domain.post.api.dto.PostBookmarkedResponse;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostSearchCondition;
 import org.colcum.admin.domain.post.domain.PostEntity;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
+import org.colcum.admin.domain.user.domain.vo.QBookmark;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -22,6 +26,7 @@ import static org.colcum.admin.domain.post.domain.QCommentEntity.commentEntity;
 import static org.colcum.admin.domain.post.domain.QEmojiReactionEntity.emojiReactionEntity;
 import static org.colcum.admin.domain.post.domain.QPostEntity.postEntity;
 import static org.colcum.admin.domain.user.domain.QUserEntity.userEntity;
+import static org.colcum.admin.domain.user.domain.vo.QBookmark.bookmark;
 
 @Component
 @RequiredArgsConstructor
@@ -36,6 +41,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         List<PostEntity> fetch = queryFactory
             .select(postEntity)
             .from(postEntity)
+            .innerJoin(postEntity.user, userEntity)
             .leftJoin(postEntity.commentEntities, commentEntity)
             .leftJoin(postEntity.emojiReactionEntities, emojiReactionEntity).fetchJoin()
             .where(builder)
@@ -89,9 +95,15 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 postEntity.title
             ))
             .from(postEntity)
-            .innerJoin(postEntity.user, userEntity)
-            .where(postEntity.isBookmarked.eq(true)
-                .and(userEntity.id.eq(userId))
+            .where(
+                postEntity.id.in(
+                    JPAExpressions
+                        .select(bookmark.postId)
+                        .from(userEntity)
+                        .join(userEntity.bookmarks, bookmark)
+                        .where(userEntity.id.eq(userId)
+                    )
+                )
             )
             .fetch();
     }

--- a/src/main/java/org/colcum/admin/domain/post/dao/CustomPostRepositoryImpl.java
+++ b/src/main/java/org/colcum/admin/domain/post/dao/CustomPostRepositoryImpl.java
@@ -1,9 +1,11 @@
 package org.colcum.admin.domain.post.dao;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.colcum.admin.domain.post.api.dto.PostBookmarkedResponse;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostSearchCondition;
 import org.colcum.admin.domain.post.domain.PostEntity;
@@ -76,6 +78,22 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 )
                 .fetchOne()
         );
+    }
+
+    @Override
+    public List<PostBookmarkedResponse> findWithBookmarked(Long userId) {
+        return queryFactory
+            .select(Projections.constructor(
+                PostBookmarkedResponse.class,
+                postEntity.id,
+                postEntity.title
+            ))
+            .from(postEntity)
+            .innerJoin(postEntity.user, userEntity)
+            .where(postEntity.isBookmarked.eq(true)
+                .and(userEntity.id.eq(userId))
+            )
+            .fetch();
     }
 
     private static BooleanBuilder getBooleanBuilder(PostSearchCondition condition) {

--- a/src/main/java/org/colcum/admin/domain/post/domain/PostEntity.java
+++ b/src/main/java/org/colcum/admin/domain/post/domain/PostEntity.java
@@ -131,4 +131,9 @@ public class PostEntity extends BaseEntity {
         return this;
     }
 
+    public PostEntity bookmarked() {
+        this.isBookmarked = true;
+        return this;
+    }
+
 }

--- a/src/main/java/org/colcum/admin/domain/post/domain/PostEntity.java
+++ b/src/main/java/org/colcum/admin/domain/post/domain/PostEntity.java
@@ -55,9 +55,6 @@ public class PostEntity extends BaseEntity {
     @Enumerated
     private PostStatus status;
 
-    @Column(nullable = false)
-    private boolean isBookmarked;
-
     private LocalDateTime expiredDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -73,24 +70,22 @@ public class PostEntity extends BaseEntity {
     @ToString.Exclude
     private List<EmojiReactionEntity> emojiReactionEntities = new ArrayList<>();
 
-    public PostEntity(String title, String content, PostCategory category, PostStatus status, boolean isBookmarked, LocalDateTime expiredDate, UserEntity user, List<CommentEntity> commentEntities, List<EmojiReactionEntity> emojiReactionEntities) {
+    public PostEntity(String title, String content, PostCategory category, PostStatus status, LocalDateTime expiredDate, UserEntity user, List<CommentEntity> commentEntities, List<EmojiReactionEntity> emojiReactionEntities) {
         this.title = title;
         this.content = content;
         this.category = category;
         this.status = status;
-        this.isBookmarked = isBookmarked;
         this.expiredDate = expiredDate;
         this.user = user;
         this.commentEntities = commentEntities;
         this.emojiReactionEntities = emojiReactionEntities;
     }
 
-    public PostEntity(String title, String content, PostCategory category, PostStatus status, boolean isBookmarked, LocalDateTime expiredDate, UserEntity user) {
+    public PostEntity(String title, String content, PostCategory category, PostStatus status, LocalDateTime expiredDate, UserEntity user) {
         this.title = title;
         this.content = content;
         this.category = category;
         this.status = status;
-        this.isBookmarked = isBookmarked;
         this.expiredDate = expiredDate;
         this.user = user;
     }
@@ -128,11 +123,6 @@ public class PostEntity extends BaseEntity {
         this.content = dto.getContent();
         this.status = dto.getStatus();
         this.expiredDate = dto.getExpiredDate();
-        return this;
-    }
-
-    public PostEntity bookmarked() {
-        this.isBookmarked = true;
         return this;
     }
 

--- a/src/main/java/org/colcum/admin/domain/user/domain/Branch.java
+++ b/src/main/java/org/colcum/admin/domain/user/domain/Branch.java
@@ -1,5 +1,0 @@
-package org.colcum.admin.domain.user.domain;
-
-public enum Branch {
-    JONGRO
-}

--- a/src/main/java/org/colcum/admin/domain/user/domain/UserEntity.java
+++ b/src/main/java/org/colcum/admin/domain/user/domain/UserEntity.java
@@ -1,21 +1,29 @@
 package org.colcum.admin.domain.user.domain;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.colcum.admin.domain.user.domain.type.Branch;
+import org.colcum.admin.domain.user.domain.type.UserType;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
 import org.colcum.admin.global.common.domain.BaseEntity;
 import org.colcum.admin.global.util.EmailValidator;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -45,6 +53,10 @@ public class UserEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserType userType = UserType.STAFF;
 
+    @ElementCollection
+    @CollectionTable(name = "bookmarks", joinColumns = @JoinColumn(name = "user_id"))
+    private Set<Bookmark> bookmarks = new HashSet<>();
+
     public UserEntity(String email, String password, String name, Branch branch) {
         EmailValidator.validate(email);
         this.email = email;
@@ -63,6 +75,14 @@ public class UserEntity extends BaseEntity {
 
     public void setType(UserType userType) {
         this.userType = userType;
+    }
+
+    public void addBookmark(Bookmark bookmark) {
+        this.bookmarks.add(bookmark);
+    }
+
+    public void removeBookmark(Bookmark bookmark) {
+        this.bookmarks.remove(bookmark);
     }
 
     @Override

--- a/src/main/java/org/colcum/admin/domain/user/domain/type/Branch.java
+++ b/src/main/java/org/colcum/admin/domain/user/domain/type/Branch.java
@@ -1,0 +1,5 @@
+package org.colcum.admin.domain.user.domain.type;
+
+public enum Branch {
+    JONGRO
+}

--- a/src/main/java/org/colcum/admin/domain/user/domain/type/UserType.java
+++ b/src/main/java/org/colcum/admin/domain/user/domain/type/UserType.java
@@ -1,4 +1,4 @@
-package org.colcum.admin.domain.user.domain;
+package org.colcum.admin.domain.user.domain.type;
 
 import lombok.Getter;
 

--- a/src/main/java/org/colcum/admin/domain/user/domain/vo/Bookmark.java
+++ b/src/main/java/org/colcum/admin/domain/user/domain/vo/Bookmark.java
@@ -2,13 +2,17 @@ package org.colcum.admin.domain.user.domain.vo;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Embeddable
+@EqualsAndHashCode
+@ToString
 public class Bookmark {
 
     private Long postId;

--- a/src/main/java/org/colcum/admin/domain/user/domain/vo/Bookmark.java
+++ b/src/main/java/org/colcum/admin/domain/user/domain/vo/Bookmark.java
@@ -1,0 +1,17 @@
+package org.colcum.admin.domain.user.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Embeddable
+public class Bookmark {
+
+    private Long postId;
+
+}
+

--- a/src/main/java/org/colcum/admin/global/auth/config/SecurityConfiguration.java
+++ b/src/main/java/org/colcum/admin/global/auth/config/SecurityConfiguration.java
@@ -1,7 +1,7 @@
 package org.colcum.admin.global.auth.config;
 
 import lombok.RequiredArgsConstructor;
-import org.colcum.admin.domain.user.domain.UserType;
+import org.colcum.admin.domain.user.domain.type.UserType;
 import org.colcum.admin.global.auth.api.AuthenticationFailureHandler;
 import org.colcum.admin.global.auth.api.AuthenticationSuccessHandler;
 import org.colcum.admin.global.auth.api.LoggingFilter;

--- a/src/test/java/org/colcum/admin/domain/post/api/PostControllerTest.java
+++ b/src/test/java/org/colcum/admin/domain/post/api/PostControllerTest.java
@@ -9,10 +9,12 @@ import org.colcum.admin.domain.post.api.dto.PostDetailResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostUpdateDto;
 import org.colcum.admin.domain.post.application.PostService;
+import org.colcum.admin.domain.post.domain.PostEntity;
 import org.colcum.admin.domain.post.domain.type.PostCategory;
 import org.colcum.admin.domain.post.domain.type.PostStatus;
 import org.colcum.admin.domain.post.domain.type.SearchType;
 import org.colcum.admin.domain.user.domain.UserEntity;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
 import org.colcum.admin.global.Error.InvalidAuthenticationException;
 import org.colcum.admin.global.Error.PostNotFoundException;
 import org.colcum.admin.global.auth.WithMockJwtAuthentication;
@@ -22,6 +24,7 @@ import org.colcum.admin.global.common.IsNullOrType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -33,15 +36,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.colcum.admin.global.util.Fixture.createFixturePost;
 import static org.colcum.admin.global.util.Fixture.createFixtureUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -404,6 +410,67 @@ class PostControllerTest extends AbstractRestDocsTest {
             )
             .andDo(print());
 
+    }
+
+    @Test
+    @DisplayName("게시글에 북마크를 한다.")
+    @WithMockJwtAuthentication
+    void addBookmark() throws Exception {
+        // given
+        UserEntity user = ((JwtAuthentication) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).userEntity;
+        Long postId = 1L;
+        Bookmark target = new Bookmark(postId);
+
+        // when
+        doAnswer(invocation -> {
+            user.addBookmark(target);
+            return null;
+        }).when(postService).addBookmark(postId, user);
+
+        // then
+        this.mockMvc
+            .perform(
+                post(MessageFormat.format("/api/v1/posts/{0}/bookmarks", postId)))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.statusCode").value(HttpStatus.OK.value()),
+                jsonPath("$.message").value("success"),
+                jsonPath("$.data").value(Matchers.nullValue())
+            )
+            .andDo(print());
+
+        assertThat(user.getBookmarks()).contains(target);
+    }
+
+    @Test
+    @DisplayName("게시글에 북마크를 제거한다.")
+    @WithMockJwtAuthentication
+    void removeBookmark() throws Exception {
+        // given
+        UserEntity user = ((JwtAuthentication) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).userEntity;
+        Long postId = 1L;
+        Bookmark target = new Bookmark(postId);
+        user.addBookmark(target);
+
+        // when
+        doAnswer(invocation -> {
+            user.removeBookmark(target);
+            return null;
+        }).when(postService).removeBookmark(postId, user);
+
+        // then
+        this.mockMvc
+            .perform(
+                delete(MessageFormat.format("/api/v1/posts/{0}/bookmarks", postId)))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.statusCode").value(HttpStatus.OK.value()),
+                jsonPath("$.message").value("success"),
+                jsonPath("$.data").value(Matchers.nullValue())
+            )
+            .andDo(print());
+
+        assertThat(user.getBookmarks()).doesNotContain(target);
     }
 
 }

--- a/src/test/java/org/colcum/admin/domain/post/application/PostServiceTest.java
+++ b/src/test/java/org/colcum/admin/domain/post/application/PostServiceTest.java
@@ -14,8 +14,8 @@ import org.colcum.admin.domain.post.domain.type.PostStatus;
 import org.colcum.admin.domain.post.domain.type.SearchType;
 import org.colcum.admin.domain.user.dao.UserRepository;
 import org.colcum.admin.domain.user.domain.UserEntity;
+import org.colcum.admin.domain.user.domain.vo.Bookmark;
 import org.colcum.admin.global.Error.PostNotFoundException;
-import org.colcum.admin.global.auth.WithMockJwtAuthentication;
 import org.colcum.admin.global.util.Fixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +27,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.io.FileNotFoundException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -132,7 +131,6 @@ class PostServiceTest {
 
         // when
         Page<PostResponseDto> allPosts = postService.findByCriteria(null, null, null, statuses, page);
-        ;
 
         // then
         assertThat(allPosts.getContent().size()).isEqualTo(NUMBER_OF_POST);
@@ -182,7 +180,6 @@ class PostServiceTest {
 
         // when
         Page<PostResponseDto> allPosts = postService.findByCriteria(null, null, categories, null, page);
-        ;
 
         // then
         assertThat(allPosts.getContent().size()).isEqualTo(NUMBER_OF_POST);
@@ -208,9 +205,7 @@ class PostServiceTest {
 
         // when
         Page<PostResponseDto> nothing = postService.findByCriteria(searchType, searchValueForNothing, null, null, page);
-        ;
         Page<PostResponseDto> allPosts = postService.findByCriteria(searchType, searchValueForAll, null, null, page);
-        ;
 
         // then
         assertThat(nothing.getContent().size()).isEqualTo(0);
@@ -237,9 +232,7 @@ class PostServiceTest {
 
         // when
         Page<PostResponseDto> nothing = postService.findByCriteria(searchType, searchValueForNothing, null, null, page);
-        ;
         Page<PostResponseDto> allPosts = postService.findByCriteria(searchType, searchValueForAll, null, null, page);
-        ;
 
         // then
         assertThat(nothing.getContent().size()).isEqualTo(0);
@@ -290,10 +283,8 @@ class PostServiceTest {
         assertThat(post.getContent()).isEqualTo(response.getContent());
         assertThat(post.getCategory()).isEqualTo(response.getCategory());
         assertThat(post.getStatus()).isEqualTo(response.getStatus());
-        assertThat(post.isBookmarked()).isEqualTo(response.isBookmarked());
         assertThat(post.getExpiredDate()).isEqualTo(response.getExpiredDate());
         assertThat(post.getUser().getName()).isEqualTo(response.getWrittenBy());
-        assertThat(post.isBookmarked()).isEqualTo(response.isBookmarked());
         assertThat(post.getCommentEntities().stream().map(CommentResponseDto::from).toList()).isEqualTo(response.getCommentResponseDtos());
         assertThat(EmojiResponseDto.from(post.getEmojiReactionEntities())).isEqualTo(response.getEmojiResponseDtos());
     }
@@ -339,7 +330,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("게시글을 삭제한다.")
-    void deletePost () {
+    void deletePost() {
         // given
         PostEntity post = Fixture.createFixturePost("title1", "content1", user);
         post = postRepository.save(post);
@@ -359,17 +350,20 @@ class PostServiceTest {
         PostEntity post1 = Fixture.createFixturePost("title1", "content1", user);
         PostEntity post2 = Fixture.createFixturePost("title2", "content2", user);
         PostEntity post3 = Fixture.createFixturePost("title3", "content3", user);
-        post1.bookmarked();
 
         post1 = postRepository.save(post1);
         postRepository.save(post2);
         postRepository.save(post3);
 
         // when
+        user.addBookmark(new Bookmark(post1.getId()));
+        user = userRepository.save(user);
         List<PostBookmarkedResponse> responses = postService.findBookmarkedPosts(user);
 
         // then
         assertThat(responses).containsExactly(PostBookmarkedResponse.from(post1));
+        assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post2));
+        assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post3));
     }
-
+    
 }

--- a/src/test/java/org/colcum/admin/domain/post/application/PostServiceTest.java
+++ b/src/test/java/org/colcum/admin/domain/post/application/PostServiceTest.java
@@ -2,6 +2,7 @@ package org.colcum.admin.domain.post.application;
 
 import org.colcum.admin.domain.post.api.dto.CommentResponseDto;
 import org.colcum.admin.domain.post.api.dto.EmojiResponseDto;
+import org.colcum.admin.domain.post.api.dto.PostBookmarkedResponse;
 import org.colcum.admin.domain.post.api.dto.PostCreateDto;
 import org.colcum.admin.domain.post.api.dto.PostDetailResponseDto;
 import org.colcum.admin.domain.post.api.dto.PostResponseDto;
@@ -349,6 +350,26 @@ class PostServiceTest {
 
         // then
         assertThrows(PostNotFoundException.class, () -> postService.inquirePostDetail(postId));
+    }
+
+    @Test
+    @DisplayName("북마크 된 게시글을 조회한다.")
+    void inquirePostsWithBookmarked() {
+        // given
+        PostEntity post1 = Fixture.createFixturePost("title1", "content1", user);
+        PostEntity post2 = Fixture.createFixturePost("title2", "content2", user);
+        PostEntity post3 = Fixture.createFixturePost("title3", "content3", user);
+        post1.bookmarked();
+
+        post1 = postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+        // when
+        List<PostBookmarkedResponse> responses = postService.findBookmarkedPosts(user);
+
+        // then
+        assertThat(responses).containsExactly(PostBookmarkedResponse.from(post1));
     }
 
 }

--- a/src/test/java/org/colcum/admin/domain/post/application/PostServiceTest.java
+++ b/src/test/java/org/colcum/admin/domain/post/application/PostServiceTest.java
@@ -365,5 +365,57 @@ class PostServiceTest {
         assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post2));
         assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post3));
     }
-    
+
+
+    @Test
+    @DisplayName("게시글에 북마크를 한다.")
+    void doBookmarkOnPost() {
+        // given
+        PostEntity post1 = Fixture.createFixturePost("title1", "content1", user);
+        PostEntity post2 = Fixture.createFixturePost("title2", "content2", user);
+        PostEntity post3 = Fixture.createFixturePost("title3", "content3", user);
+
+        post1 = postRepository.save(post1);
+        postRepository.save(post2);
+        postRepository.save(post3);
+
+        // when
+        postService.addBookmark(post1.getId(), user);
+        List<PostBookmarkedResponse> responses = postService.findBookmarkedPosts(user);
+
+        // then
+        assertThat(responses).containsExactly(PostBookmarkedResponse.from(post1));
+        assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post2));
+        assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post3));
+    }
+
+    @Test
+    @DisplayName("게시글에 북마크를 제거한다.")
+    void removeBookmarkOnPost() {
+        // given
+        PostEntity post1 = Fixture.createFixturePost("title1", "content1", user);
+        PostEntity post2 = Fixture.createFixturePost("title2", "content2", user);
+        PostEntity post3 = Fixture.createFixturePost("title3", "content3", user);
+
+        post1 = postRepository.save(post1);
+        post2 = postRepository.save(post2);
+        post3 = postRepository.save(post3);
+
+        Bookmark target = new Bookmark(post1.getId());
+
+        // when
+        user.addBookmark(target);
+        user.addBookmark(new Bookmark(post2.getId()));
+        user.addBookmark(new Bookmark(post3.getId()));
+        user = userRepository.save(user);
+
+        postService.removeBookmark(target.getPostId(), user);
+        List<PostBookmarkedResponse> responses = postService.findBookmarkedPosts(user);
+
+        // then
+        assertThat(responses).doesNotContain(PostBookmarkedResponse.from(post1));
+        assertThat(responses).contains(PostBookmarkedResponse.from(post2));
+        assertThat(responses).contains(PostBookmarkedResponse.from(post3));
+    }
+
 }

--- a/src/test/java/org/colcum/admin/global/auth/WithMockJwtAuthenticationSecurityContextFactory.java
+++ b/src/test/java/org/colcum/admin/global/auth/WithMockJwtAuthenticationSecurityContextFactory.java
@@ -1,6 +1,6 @@
 package org.colcum.admin.global.auth;
 
-import org.colcum.admin.domain.user.domain.Branch;
+import org.colcum.admin.domain.user.domain.type.Branch;
 import org.colcum.admin.domain.user.domain.UserEntity;
 import org.colcum.admin.global.auth.jwt.JwtAuthentication;
 import org.colcum.admin.global.auth.jwt.JwtAuthenticationToken;

--- a/src/test/java/org/colcum/admin/global/util/Fixture.java
+++ b/src/test/java/org/colcum/admin/global/util/Fixture.java
@@ -5,10 +5,9 @@ import org.colcum.admin.domain.post.domain.EmojiReactionEntity;
 import org.colcum.admin.domain.post.domain.type.PostCategory;
 import org.colcum.admin.domain.post.domain.PostEntity;
 import org.colcum.admin.domain.post.domain.type.PostStatus;
-import org.colcum.admin.domain.user.domain.Branch;
+import org.colcum.admin.domain.user.domain.type.Branch;
 import org.colcum.admin.domain.user.domain.UserEntity;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,11 +15,11 @@ import java.util.List;
 public class Fixture {
 
     public static PostEntity createFixturePost(String title, String content, UserEntity user) {
-        return createFixturePost(title, content, PostCategory.ANNOUNCEMENT, PostStatus.UNCOMPLETED, false, null, user, new ArrayList<>(), new ArrayList<>());
+        return createFixturePost(title, content, PostCategory.ANNOUNCEMENT, PostStatus.UNCOMPLETED, null, user, new ArrayList<>(), new ArrayList<>());
     }
 
-    public static PostEntity createFixturePost(String title, String content, PostCategory postCategory, PostStatus postStatus, boolean isBookmarked, LocalDateTime expiredDate, UserEntity user, List<CommentEntity> comments, List<EmojiReactionEntity> emojis) {
-        return new PostEntity(title, content, postCategory, postStatus, isBookmarked, expiredDate, user, comments, emojis);
+    public static PostEntity createFixturePost(String title, String content, PostCategory postCategory, PostStatus postStatus, LocalDateTime expiredDate, UserEntity user, List<CommentEntity> comments, List<EmojiReactionEntity> emojis) {
+        return new PostEntity(title, content, postCategory, postStatus, expiredDate, user, comments, emojis);
     }
 
     public static UserEntity createFixtureUser() {


### PR DESCRIPTION
## #️⃣연관된 이슈번호
this close #18 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 북마크 관련 API를 구현했습니다.
   - 기존 Post에 필드로 있었던 boolean isBookmarked는 User와의 관계가 고려되지 않은 필드이므로 삭제되고,
     대신 User 필드에 Set<Bookmark> 라는 값 객체의 리스트를 가지도록 하였습니다.
   - 북마크 조회, 생성, 삭제 기능을 구현했습니다.